### PR TITLE
feat(ios): Implement core features for Forex app MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,44 @@
 # example-maui-notification
 
 This is a MAUI application.
+
+## プッシュ通知仕様 (iOS)
+
+iOSアプリはバックエンドサービスから送信されるプッシュ通知を受信して、OSの通知センターに表示します。以下は、アプリが期待するプッシュ通知のペイロード形式です。
+
+### ペイロード形式
+
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "為替アラート",
+      "body": "MXN/JPY が過去1ヶ月平均より10%下落しました！"
+    },
+    "sound": "default",
+    "badge": 1
+  },
+  "notification_type": "PRICE_ALERT",
+  "currency_pair": "MXN/JPY",
+  "event_time": "2023-10-27T17:00:00Z",
+  "details": {
+    "current_price": 7.5,
+    "monthly_average": 8.33
+  }
+}
+```
+
+### キーの説明
+
+*   **`aps`** (オブジェクト): Apple Push Notification service (APNs) が使用する予約済みのキー。
+    *   **`alert`** (オブジェクト): 通知の表示内容。
+        *   **`title`** (文字列): 通知のタイトル。
+        *   **`body`** (文字列): 通知の本文。
+    *   **`sound`** (文字列): 通知音。`default` を指定すると標準の通知音が鳴ります。
+    *   **`badge`** (数値, オプション): アプリアイコンに表示するバッジナンバー。
+*   **`notification_type`** (文字列): 通知の種類を識別するためのカスタムキー。例: `PRICE_ALERT`。
+*   **`currency_pair`** (文字列): 通知に関連する通貨ペア。例: `MXN/JPY`。
+*   **`event_time`** (文字列): イベント（例: 価格アラート条件合致）が発生した時刻 (ISO 8601形式)。
+*   **`details`** (オブジェクト, オプション): 通知に関する追加の詳細情報を含むカスタムオブジェクト。
+    *   **`current_price`** (数値, オプション): イベント発生時の現在価格。
+    *   **`monthly_average`** (数値, オプション): イベント発生時の月間平均価格。

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -1,0 +1,77 @@
+import UIKit
+import UserNotifications // Required for push notifications
+
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+        UNUserNotificationCenter.current().delegate = self
+
+        // Request notification authorization
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+            if let error = error {
+                print("Error requesting notification authorization: \(error.localizedDescription)")
+                return
+            }
+            if granted {
+                print("Notification permission granted.")
+                // Register for remote notifications on the main thread
+                DispatchQueue.main.async {
+                    UIApplication.shared.registerForRemoteNotifications()
+                }
+            } else {
+                print("Notification permission denied.")
+            }
+        }
+        return true
+    }
+
+    // Successfully registered for remote notifications and received device token
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        let tokenParts = deviceToken.map { data in String(format: "%02.2hhx", data) }
+        let token = tokenParts.joined()
+        print("Device Token: \(token)")
+        // Here you would typically send the token to your backend server
+    }
+
+    // Failed to register for remote notifications
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        print("Failed to register for remote notifications: \(error.localizedDescription)")
+    }
+
+    // MARK: - UNUserNotificationCenterDelegate
+
+    // Handle notification when the app is in the foreground
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+
+        let userInfo = notification.request.content.userInfo
+        print("Notification received in foreground: \(userInfo)")
+
+        // Show alert, sound, and badge while app is in foreground
+        // For iOS 14 and later, .list and .banner are available.
+        if #available(iOS 14.0, *) {
+            completionHandler([.banner, .sound, .list, .badge]) // Added .badge as well
+        } else {
+            completionHandler([.alert, .sound, .badge])
+        }
+    }
+
+    // Handle user's response to a delivered notification (e.g., tapping it)
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler completionHandler: @escaping () -> Void) {
+
+        let userInfo = response.notification.request.content.userInfo
+        print("Notification tapped (or other action): \(userInfo)")
+
+        // Example: You could extract data from userInfo to navigate to a specific part of the app
+        // if let customData = userInfo["custom_key"] as? String {
+        //     print("Custom data received: \(customData)")
+        // }
+
+        // Make sure to call the completion handler when you're done processing the response
+        completionHandler()
+    }
+}

--- a/iOS/MiserApp.swift
+++ b/iOS/MiserApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+@main
+struct MiserApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView() // Assuming ContentView is the main view
+        }
+    }
+}

--- a/iOS/MiserTests/DummyDataGeneratorTests.swift
+++ b/iOS/MiserTests/DummyDataGeneratorTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import Miser // Replace 'Miser' with the actual module name
+
+class DummyDataGeneratorTests: XCTestCase {
+
+    func testGenerateData_ReturnsCorrectNumberOfDays() {
+        let daysToTest = [1, 10, 30, 180, 365]
+        let pairsToTest: [ForexPair] = [.mxnjpy, .zarjpy]
+
+        for pair in pairsToTest {
+            for days in daysToTest {
+                let dataPoints = DummyDataGenerator.generateData(for: pair, days: days)
+                XCTAssertEqual(dataPoints.count, days, "Should generate \(days) data points for \(pair.rawValue), but got \(dataPoints.count).")
+            }
+        }
+    }
+
+    func testGenerateData_DataPointsAreSortedByDateAscending() {
+        let dataPointsMxnjpy = DummyDataGenerator.generateData(for: .mxnjpy, days: 30)
+        XCTAssertTrue(dataPointsMxnjpy.count > 1, "Need more than 1 data point to test sorting.")
+        for i in 0..<(dataPointsMxnjpy.count - 1) {
+            XCTAssertLessThanOrEqual(dataPointsMxnjpy[i].date, dataPointsMxnjpy[i+1].date, "MXN/JPY data points should be sorted by date ascending.")
+        }
+
+        let dataPointsZarjpy = DummyDataGenerator.generateData(for: .zarjpy, days: 30)
+        XCTAssertTrue(dataPointsZarjpy.count > 1, "Need more than 1 data point to test sorting.")
+        for i in 0..<(dataPointsZarjpy.count - 1) {
+            XCTAssertLessThanOrEqual(dataPointsZarjpy[i].date, dataPointsZarjpy[i+1].date, "ZAR/JPY data points should be sorted by date ascending.")
+        }
+    }
+
+    func testGenerateData_OHLCLogicIsValid() {
+        let dataPoints = DummyDataGenerator.generateData(for: .mxnjpy, days: 30)
+        XCTAssertFalse(dataPoints.isEmpty, "Generated data should not be empty.")
+
+        for point in dataPoints {
+            XCTAssertGreaterThanOrEqual(point.high, point.open, "High should be >= Open for \(point.date)")
+            XCTAssertGreaterThanOrEqual(point.high, point.close, "High should be >= Close for \(point.date)")
+            XCTAssertGreaterThanOrEqual(point.high, point.low, "High should be >= Low for \(point.date)")
+
+            XCTAssertLessThanOrEqual(point.low, point.open, "Low should be <= Open for \(point.date)")
+            XCTAssertLessThanOrEqual(point.low, point.close, "Low should be <= Close for \(point.date)")
+
+            // Check that open and close are within high/low range
+            XCTAssertGreaterThanOrEqual(point.open, point.low, "Open should be >= Low for \(point.date)")
+            XCTAssertLessThanOrEqual(point.open, point.high, "Open should be <= High for \(point.date)")
+            XCTAssertGreaterThanOrEqual(point.close, point.low, "Close should be >= Low for \(point.date)")
+            XCTAssertLessThanOrEqual(point.close, point.high, "Close should be <= High for \(point.date)")
+        }
+    }
+
+    func testGenerateData_PairNameIsCorrect() {
+        let mxnData = DummyDataGenerator.generateData(for: .mxnjpy, days: 10)
+        for point in mxnData {
+            XCTAssertEqual(point.pairName, .mxnjpy, "All data points should have pairName .mxnjpy.")
+        }
+
+        let zarData = DummyDataGenerator.generateData(for: .zarjpy, days: 10)
+        for point in zarData {
+            XCTAssertEqual(point.pairName, .zarjpy, "All data points should have pairName .zarjpy.")
+        }
+    }
+
+    func testDaysForPeriod_ReturnsCorrectValues() {
+        XCTAssertEqual(DummyDataGenerator.days(for: .tenDays), 10)
+        XCTAssertEqual(DummyDataGenerator.days(for: .thirtyDays), 30)
+        XCTAssertEqual(DummyDataGenerator.days(for: .sixMonths), 180) // Approx.
+        XCTAssertEqual(DummyDataGenerator.days(for: .oneYear), 365)
+        XCTAssertEqual(DummyDataGenerator.days(for: .fiveYears), 365 * 5)
+    }
+
+    func testGenerateData_DifferentBasePricesForPairs() {
+        // This test is a bit more heuristic, checking general price ranges
+        let mxnData = DummyDataGenerator.generateData(for: .mxnjpy, days: 30)
+        let zarData = DummyDataGenerator.generateData(for: .zarjpy, days: 30)
+
+        XCTAssertFalse(mxnData.isEmpty)
+        XCTAssertFalse(zarData.isEmpty)
+
+        // Calculate average close price for MXN/JPY
+        let avgCloseMxnjpy = mxnData.reduce(0.0) { $0 + $1.close } / Double(mxnData.count)
+        // Calculate average close price for ZAR/JPY
+        let avgCloseZarjpy = zarData.reduce(0.0) { $0 + $1.close } / Double(zarData.count)
+
+        // Assuming MXN/JPY (e.g., ~8.0) is generally higher than ZAR/JPY (e.g., ~7.0) as per generator's basePrice
+        // Allow for some overlap due to randomness, so not a strict inequality test
+        // A more robust test would check against the basePrice +/- volatility range if those were exposed
+        // For now, let's check they are not identical and somewhat different,
+        // which implies different base prices were likely used.
+        XCTAssertNotEqual(avgCloseMxnjpy, avgCloseZarjpy, "Average prices for MXN/JPY and ZAR/JPY should differ, implying different base prices.")
+        // A slightly more specific check based on the known base prices (8.0 and 7.0)
+        // This is still a bit fragile if randomness is very high.
+        XCTAssertTrue(avgCloseMxnjpy > 6.0 && avgCloseMxnjpy < 10.0, "MXN/JPY avg price seems out of expected range (around 8.0)")
+        XCTAssertTrue(avgCloseZarjpy > 5.0 && avgCloseZarjpy < 9.0, "ZAR/JPY avg price seems out of expected range (around 7.0)")
+
+    }
+}

--- a/iOS/MiserTests/DummyNewsGeneratorTests.swift
+++ b/iOS/MiserTests/DummyNewsGeneratorTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import Miser // Replace 'Miser' with the actual module name
+
+class DummyNewsGeneratorTests: XCTestCase {
+
+    func testGenerateAllNews_ReturnsNonEmptyArray() {
+        let newsItems = DummyNewsGenerator.generateAllNews()
+        XCTAssertFalse(newsItems.isEmpty, "Generated news items array should not be empty.")
+    }
+
+    func testGenerateAllNews_ItemsHaveRequiredPropertiesSet() {
+        let newsItems = DummyNewsGenerator.generateAllNews()
+        XCTAssertFalse(newsItems.isEmpty, "Test requires generated news items.")
+
+        for item in newsItems {
+            // country and indicator are non-optional enum types, so they are always set.
+            XCTAssertFalse(item.value.isEmpty, "News item value should not be empty for item ID \(item.id).")
+            // publishedDate is non-optional Date, so it's always set.
+            // We can check if the date is recent, e.g., not more than a few days in the past from now.
+            let now = Date()
+            // Dummy generator creates dates up to i*5 days ago, max i is 1 (0..<2), so max 5 days ago.
+            // Let's give it a bit more buffer for safety in test.
+            let reasonablePastDateLimit = Calendar.current.date(byAdding: .day, value: -15, to: now)!
+            XCTAssertTrue(item.publishedDate >= reasonablePastDateLimit && item.publishedDate <= now, "Published date \(item.publishedDateString) for item ID \(item.id) (\(item.country.rawValue) - \(item.indicator.rawValue)) seems too old or in the future.")
+
+            // Optional properties notes and sourceLink can be nil, so no check for non-nil here unless specific items are expected to have them.
+        }
+    }
+
+    func testGenerateAllNews_ItemsAreSortedCorrectly() {
+        let newsItems = DummyNewsGenerator.generateAllNews()
+        guard newsItems.count > 1 else {
+            XCTFail("Need more than 1 item to test sorting. Generated \(newsItems.count) items.")
+            return
+        }
+
+        for i in 0..<(newsItems.count - 1) {
+            let currentItem = newsItems[i]
+            let nextItem = newsItems[i+1]
+
+            // Primary sort: Date descending
+            if currentItem.publishedDate != nextItem.publishedDate {
+                XCTAssertGreaterThanOrEqual(currentItem.publishedDate, nextItem.publishedDate, "News items should be sorted by publishedDate descending primarily. Failed for \(currentItem.id) and \(nextItem.id).")
+            }
+            // Secondary sort: Country rawValue ascending (if dates are same)
+            else if currentItem.country.rawValue != nextItem.country.rawValue {
+                 XCTAssertLessThanOrEqual(currentItem.country.rawValue, nextItem.country.rawValue, "For same date, items should be sorted by country ascending. Failed for \(currentItem.id) (\(currentItem.country.rawValue)) and \(nextItem.id) (\(nextItem.country.rawValue)).")
+            }
+            // Tertiary sort: Indicator rawValue ascending (if dates and countries are same)
+            else {
+                 XCTAssertLessThanOrEqual(currentItem.indicator.rawValue, nextItem.indicator.rawValue, "For same date and country, items should be sorted by indicator ascending. Failed for \(currentItem.id) (\(currentItem.indicator.rawValue)) and \(nextItem.id) (\(nextItem.indicator.rawValue)).")
+            }
+        }
+    }
+
+    func testGenerateAllNews_ValuesArePlausible() {
+        let newsItems = DummyNewsGenerator.generateAllNews()
+        XCTAssertFalse(newsItems.isEmpty, "Test requires generated news items.")
+
+        for item in newsItems {
+            switch item.indicator {
+            case .cpi:
+                XCTAssertTrue(item.value.contains("%") && item.value.contains("前年同月比"), "CPI value '\(item.value)' for ID \(item.id) doesn't seem plausible.")
+            case .interestRate:
+                XCTAssertTrue(item.value.contains("%"), "Interest rate value '\(item.value)' for ID \(item.id) doesn't seem plausible (missing '%').")
+            case .tradeBalance:
+                let hasNumber = item.value.rangeOfCharacter(from: .decimalDigits) != nil
+                let hasOku = item.value.contains("億")
+
+                let currencyCode: String
+                switch item.country {
+                case .japan: currencyCode = "JPY"
+                case .usa: currencyCode = "USD"
+                case .mexico: currencyCode = "MXN"
+                case .southAfrica: currencyCode = "ZAR"
+                }
+                let hasCurrency = item.value.contains(currencyCode)
+
+                XCTAssertTrue(hasNumber && hasOku && hasCurrency, "Trade balance value '\(item.value)' for ID \(item.id) (country: \(item.country.rawValue), expected currency: \(currencyCode)) doesn't seem plausible.")
+            }
+        }
+    }
+}

--- a/iOS/MiserTests/EconomicNewsViewModelTests.swift
+++ b/iOS/MiserTests/EconomicNewsViewModelTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import Miser // Replace 'Miser' with the actual module name
+
+class EconomicNewsViewModelTests: XCTestCase {
+
+    var sut: EconomicNewsViewModel!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // For this ViewModel, re-initializing in each test is fine.
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+        try super.tearDownWithError()
+    }
+
+    func testInitialization_LoadsAndGroupsNewsData() {
+        sut = EconomicNewsViewModel()
+
+        // DummyNewsGenerator is synchronous, so data should be available.
+        XCTAssertFalse(sut.isLoading, "isLoading should be false after initialization.")
+
+        // Check if countries list is populated (assuming DummyNewsGenerator provides data for some countries)
+        // If DummyNewsGenerator *might* return no news, this test needs adjustment.
+        // Assuming it always generates some news:
+        XCTAssertFalse(sut.countries.isEmpty, "Countries list should not be empty if dummy news is generated.")
+        XCTAssertFalse(sut.newsItemsByCountry.isEmpty, "News items by country dictionary should not be empty.")
+
+        // Verify that the number of countries in the list matches the number of groups in the dictionary
+        XCTAssertEqual(sut.countries.count, sut.newsItemsByCountry.keys.count, "Count of countries in list should match keys in dictionary.")
+    }
+
+    func testNewsData_IsGroupedCorrectlyByCountry() {
+        sut = EconomicNewsViewModel()
+        XCTAssertFalse(sut.newsItemsByCountry.isEmpty, "News items should be loaded.")
+
+        for (countryKey, newsItems) in sut.newsItemsByCountry {
+            XCTAssertFalse(newsItems.isEmpty, "News item list for country \(countryKey.rawValue) should not be empty if the country key exists.")
+            for item in newsItems {
+                XCTAssertEqual(item.country, countryKey, "Each news item in the list for \(countryKey.rawValue) should belong to that country.")
+            }
+        }
+    }
+
+    func testCountriesList_OrderAndContent() {
+        sut = EconomicNewsViewModel()
+        // Assuming DummyNewsGenerator generates news for all countries in NewsCountry.allCases for this test to be robust.
+        // If not, the test should only check that sut.countries is a subset of NewsCountry.allCases and maintains the order.
+
+        let expectedCountries = NewsCountry.allCases.filter { sut.newsItemsByCountry[$0]?.isEmpty == false }
+
+        XCTAssertEqual(sut.countries.count, expectedCountries.count, "ViewModel's countries count should match expected countries with news.")
+        XCTAssertEqual(sut.countries, expectedCountries, "ViewModel's countries should be the expected countries (those with news, in enum order).")
+    }
+
+    func testNewsItems_ArePresentAfterLoading() { // Renamed for clarity based on previous notes
+        sut = EconomicNewsViewModel()
+        // The DummyNewsGenerator sorts its overall output. The ViewModel groups this data.
+        // This test ensures that after grouping, there are still news items present.
+
+        var totalItems = 0
+        for country in sut.countries {
+            if let items = sut.newsItemsByCountry[country] {
+                totalItems += items.count
+                // Optionally, check if items within this specific group are sorted if that's a ViewModel responsibility.
+                // As of now, ViewModel doesn't re-sort items within the group. DummyNewsGenerator sorts the initial flat list.
+            }
+        }
+        XCTAssertTrue(totalItems > 0, "There should be at least one news item in total across all grouped countries.")
+
+        // Further check: ensure that for each country in sut.countries, there's a non-empty list in newsItemsByCountry
+        for country in sut.countries {
+            XCTAssertNotNil(sut.newsItemsByCountry[country], "Country \(country.rawValue) listed in `countries` should have an entry in `newsItemsByCountry`.")
+            XCTAssertFalse(sut.newsItemsByCountry[country]!.isEmpty, "News items for country \(country.rawValue) should not be empty.")
+        }
+    }
+}

--- a/iOS/MiserTests/ForexViewModelTests.swift
+++ b/iOS/MiserTests/ForexViewModelTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import Miser // Replace 'Miser' with the actual module name of your app
+
+class ForexViewModelTests: XCTestCase {
+
+    var sut: ForexViewModel! // System Under Test
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // Initialize sut here if it's expensive or needs to be reset cleanly for each test.
+        // For this ViewModel, re-initializing in each test is fine.
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+        try super.tearDownWithError()
+    }
+
+    func testInitialization_LoadsDefaultData() {
+        sut = ForexViewModel() // Default init: .mxnjpy, .thirtyDays
+
+        // Expectations for Combine publishers can be tricky without a helper library.
+        // For simplicity, we'll check after a brief delay or rely on synchronous dummy data.
+        // DummyDataGenerator is synchronous, so data should be available immediately after init.
+
+        XCTAssertFalse(sut.chartDataPoints.isEmpty, "Chart data should be loaded on initialization.")
+        XCTAssertEqual(sut.selectedPair, .mxnjpy, "Default pair should be .mxnjpy.")
+        XCTAssertEqual(sut.selectedPeriod, .thirtyDays, "Default period should be .thirtyDays.")
+        XCTAssertEqual(sut.chartDataPoints.count, DummyDataGenerator.days(for: .thirtyDays), "Data count should match default period (30 days).")
+    }
+
+    func testUpdatePair_ReloadsDataCorrectly() {
+        sut = ForexViewModel(initialPair: .mxnjpy, initialPeriod: .tenDays) // Start with a known state
+        let initialDataCount = sut.chartDataPoints.count
+        XCTAssertEqual(initialDataCount, DummyDataGenerator.days(for: .tenDays))
+        if let firstPointPair = sut.chartDataPoints.first?.pairName {
+             XCTAssertEqual(firstPointPair, .mxnjpy, "Initial data should be for mxnjpy.")
+        }
+
+
+        sut.updatePair(to: .zarjpy)
+
+        XCTAssertEqual(sut.selectedPair, .zarjpy, "Selected pair should be updated to .zarjpy.")
+        // Data should be reloaded for the new pair, count should remain for the same period
+        XCTAssertEqual(sut.chartDataPoints.count, DummyDataGenerator.days(for: .tenDays), "Data count should still match the initial period (10 days) for the new pair.")
+        XCTAssertFalse(sut.chartDataPoints.isEmpty, "Chart data should not be empty after pair update.")
+        if let firstPointPairAfterUpdate = sut.chartDataPoints.first?.pairName {
+            XCTAssertEqual(firstPointPairAfterUpdate, .zarjpy, "Updated data should be for .zarjpy.")
+        }
+    }
+
+    func testUpdatePeriod_ReloadsDataCorrectly() {
+        sut = ForexViewModel(initialPair: .mxnjpy, initialPeriod: .tenDays)
+        XCTAssertEqual(sut.chartDataPoints.count, DummyDataGenerator.days(for: .tenDays))
+
+        sut.updatePeriod(to: .thirtyDays)
+
+        XCTAssertEqual(sut.selectedPeriod, .thirtyDays, "Selected period should be updated to .thirtyDays.")
+        XCTAssertEqual(sut.chartDataPoints.count, DummyDataGenerator.days(for: .thirtyDays), "Data count should match the new period (30 days).")
+        XCTAssertFalse(sut.chartDataPoints.isEmpty, "Chart data should not be empty after period update.")
+         if let firstPointPair = sut.chartDataPoints.first?.pairName {
+             XCTAssertEqual(firstPointPair, .mxnjpy, "Data should still be for the initial pair (mxnjpy) after period update.")
+        }
+    }
+
+    func testDataPointCount_MatchesSelectedPeriod_ForAllPeriods() {
+        sut = ForexViewModel(initialPair: .mxnjpy, initialPeriod: .tenDays) // Start with any period
+
+        for period in ChartPeriod.allCases {
+            sut.updatePeriod(to: period)
+            XCTAssertEqual(sut.chartDataPoints.count, DummyDataGenerator.days(for: period), "Data count for \(period.rawValue) should be \(DummyDataGenerator.days(for: period)).")
+        }
+    }
+
+    func testChartDataPoints_AreForSelectedPair() {
+        sut = ForexViewModel(initialPair: .mxnjpy, initialPeriod: .tenDays)
+
+        // Check initial pair
+        for dataPoint in sut.chartDataPoints {
+            XCTAssertEqual(dataPoint.pairName, .mxnjpy, "All data points should be for MXN/JPY initially.")
+        }
+
+        // Change pair and check again
+        sut.updatePair(to: .zarjpy)
+        for dataPoint in sut.chartDataPoints {
+            XCTAssertEqual(dataPoint.pairName, .zarjpy, "All data points should be for ZAR/JPY after update.")
+        }
+    }
+}
+
+// Make sure ForexViewModel, ForexPair, ChartPeriod, DummyDataGenerator, ForexDataPoint are accessible.
+// This might require them to have public or internal access levels and the app module to be imported with @testable.
+// The module name 'Miser' in '@testable import Miser' should match your project's module name.

--- a/iOS/Models/EconomicNewsItem.swift
+++ b/iOS/Models/EconomicNewsItem.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+enum NewsCountry: String, CaseIterable, Identifiable {
+    case mexico = "メキシコ"
+    case southAfrica = "南アフリカ"
+    case japan = "日本"
+    case usa = "アメリカ"
+
+    var id: String { self.rawValue }
+}
+
+enum NewsIndicator: String, CaseIterable, Identifiable {
+    case tradeBalance = "貿易収支"
+    case interestRate = "金利"
+    case cpi = "CPI (消費者物価指数)"
+    // Add more indicators as needed
+
+    var id: String { self.rawValue }
+
+    // Helper to provide a more descriptive title if needed, or units
+    var descriptiveTitle: String {
+        switch self {
+        case .tradeBalance:
+            return "貿易収支"
+        case .interestRate:
+            return "政策金利"
+        case .cpi:
+            return "消費者物価指数 (前年同月比)"
+        }
+    }
+}
+
+struct EconomicNewsItem: Identifiable {
+    let id = UUID()
+    let country: NewsCountry
+    let indicator: NewsIndicator
+    let value: String // Example: "+2.5%", "120億USDの黒字", "5.25%"
+    let publishedDate: Date
+    let notes: String? // Optional field for more details or context
+    let sourceLink: URL? // Optional link to the source of the news
+
+    // Formatter for displaying dates
+    static var dateFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        // formatter.locale = Locale(identifier: "ja_JP") // Uncomment if Japanese locale is desired
+        return formatter
+    }
+
+    var publishedDateString: String {
+        return Self.dateFormatter.string(from: publishedDate)
+    }
+}

--- a/iOS/Models/ForexData.swift
+++ b/iOS/Models/ForexData.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+// 通貨ペアの種別を定義するenum (オプション、必要に応じて拡張)
+enum ForexPair: String, CaseIterable, Identifiable {
+    case mxnjpy = "MXN/JPY"
+    case zarjpy = "ZAR/JPY"
+
+    var id: String { self.rawValue }
+}
+
+// 単一の為替データポイントを表す構造体
+struct ForexDataPoint: Identifiable {
+    let id = UUID() // Identifiableプロトコル準拠
+    let pairName: ForexPair // 通貨ペア名
+    let date: Date       // 日時
+    let high: Double     // 高値
+    let low: Double      // 安値
+    let open: Double     // 始値
+    let close: Double    // 終値
+}

--- a/iOS/Utils/DummyDataGenerator.swift
+++ b/iOS/Utils/DummyDataGenerator.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+struct DummyDataGenerator {
+
+    static func generateData(for pair: ForexPair, days: Int) -> [ForexDataPoint] {
+        var dataPoints: [ForexDataPoint] = []
+        let calendar = Calendar.current
+        let today = Date()
+        let basePrice: Double
+        let volatility: Double // 価格変動の度合い
+
+        switch pair {
+        case .mxnjpy:
+            basePrice = 8.0 // MXN/JPYのおおよその価格帯
+            volatility = 0.15 // MXN/JPYの価格変動幅
+        case .zarjpy:
+            basePrice = 7.0 // ZAR/JPYのおおよその価格帯
+            volatility = 0.20 // ZAR/JPYの価格変動幅
+        }
+
+        for i in 0..<days {
+            guard let date = calendar.date(byAdding: .day, value: -i, to: today) else {
+                continue
+            }
+
+            // 1日の始まりの価格（前日の終値を参考にすることもできるが、ここでは単純化）
+            let openPrice: Double
+            if let lastClose = dataPoints.last?.close, i > 0 {
+                // 前日の終値から少し変動させる
+                openPrice = lastClose + Double.random(in: -volatility/2...volatility/2)
+            } else {
+                openPrice = basePrice + Double.random(in: -volatility...volatility)
+            }
+
+            let highPrice = openPrice + Double.random(in: 0...volatility)
+            let lowPrice = openPrice - Double.random(in: 0...volatility)
+            // 終値は高値と安値の間でランダムに決定 (ただし、始値から大きく離れすぎないように調整も可能)
+            let closePrice = Double.random(in: min(openPrice,lowPrice)...max(openPrice,highPrice))
+
+            // 高値・安値が始値・終値の範囲を正しく含むように調整
+            let actualHigh = max(highPrice, openPrice, closePrice)
+            let actualLow = min(lowPrice, openPrice, closePrice)
+
+            dataPoints.append(ForexDataPoint(
+                pairName: pair,
+                date: date,
+                high: actualHigh,
+                low: actualLow,
+                open: openPrice,
+                close: closePrice
+            ))
+        }
+        // 日付昇順に並び替える
+        return dataPoints.sorted { $0.date < $1.date }
+    }
+
+    // 事前に定義された期間に対応する日数を返すヘルパー
+    static func days(for period: ChartPeriod) -> Int {
+        switch period {
+        case .tenDays: return 10
+        case .thirtyDays: return 30
+        case .sixMonths: return 180 // 約
+        case .oneYear: return 365
+        case .fiveYears: return 365 * 5
+        }
+    }
+}
+
+// チャート表示期間のenum (ViewModelやViewで使うことを想定)
+enum ChartPeriod: String, CaseIterable, Identifiable {
+    case tenDays = "10D"
+    case thirtyDays = "30D"
+    case sixMonths = "6M"
+    case oneYear = "1Y"
+    case fiveYears = "5Y"
+
+    var id: String { self.rawValue }
+}

--- a/iOS/Utils/DummyNewsGenerator.swift
+++ b/iOS/Utils/DummyNewsGenerator.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+struct DummyNewsGenerator {
+
+    static func generateAllNews() -> [EconomicNewsItem] {
+        var allNews: [EconomicNewsItem] = []
+        let calendar = Calendar.current
+        let today = Date()
+
+        for country in NewsCountry.allCases {
+            for indicator in NewsIndicator.allCases {
+                // Generate 1 or 2 recent news items for each combination
+                for i in 0..<Int.random(in: 1...2) {
+                    guard let date = calendar.date(byAdding: .day, value: -(i * Int.random(in: 1...5)), to: today) else { // Random recent days
+                        continue
+                    }
+
+                    let value = generateValue(for: indicator, country: country)
+                    let notes = generateNotes(for: indicator)
+                    let link = generateSourceLink(for: country, indicator: indicator)
+
+                    allNews.append(EconomicNewsItem(
+                        country: country,
+                        indicator: indicator,
+                        value: value,
+                        publishedDate: date,
+                        notes: notes,
+                        sourceLink: link
+                    ))
+                }
+            }
+        }
+        // Sort by date, most recent first, then by country, then by indicator
+        return allNews.sorted {
+            if $0.publishedDate != $1.publishedDate {
+                return $0.publishedDate > $1.publishedDate
+            } else if $0.country.rawValue != $1.country.rawValue {
+                return $0.country.rawValue < $1.country.rawValue
+            } else {
+                return $0.indicator.rawValue < $1.indicator.rawValue
+            }
+        }
+    }
+
+    private static func generateValue(for indicator: NewsIndicator, country: NewsCountry) -> String {
+        let randomPercentage = String(format: "%.1f%%", Double.random(in: -5.0...5.0))
+        let randomPositivePercentage = String(format: "%.1f%%", Double.random(in: 0.5...5.0))
+        let randomRate = String(format: "%.2f%%", Double.random(in: 0.1...7.5))
+
+        let currency: String
+        switch country {
+        case .japan: currency = "JPY"
+        case .usa: currency = "USD"
+        case .mexico: currency = "MXN"
+        case .southAfrica: currency = "ZAR"
+        }
+        // Simplified trade balance, could be more specific (e.g., "億" + currency)
+        let randomTradeBalance = "\(Int.random(in: -500...500))億 \(currency)"
+
+
+        switch indicator {
+        case .tradeBalance:
+            return randomTradeBalance
+        case .interestRate:
+            return randomRate
+        case .cpi:
+            return "\(randomPercentage) (前年同月比)"
+        }
+    }
+
+    private static func generateNotes(for indicator: NewsIndicator) -> String? {
+        let notesPool = [
+            "市場予想を上回る結果となりました。",
+            "市場予想を下回りました。",
+            "ほぼ予想通りの数値です。",
+            "今後の経済動向に注目が集まります。",
+            nil, // Occasionally no notes
+            "詳細はレポートをご確認ください。"
+        ]
+        return notesPool.randomElement()! // Force unwrap as nil is a valid element
+    }
+
+    private static func generateSourceLink(for country: NewsCountry, indicator: NewsIndicator) -> URL? {
+        // Dummy URLs, replace with actual sources if available
+        let urls = [
+            "https://www.example-news.com/\(country.rawValue.lowercased())/\(indicator.rawValue.lowercased().filter {!$0.isWhitespace})",
+            "https://www.another-source.org/reports/\(country.rawValue.lowercased())/latest-\(indicator.rawValue.lowercased().filter {!$0.isWhitespace}).html",
+            nil // Occasionally no link
+        ]
+        if let urlString = urls.randomElement() as? String {
+            return URL(string: urlString)
+        }
+        return nil
+    }
+}

--- a/iOS/ViewModels/EconomicNewsViewModel.swift
+++ b/iOS/ViewModels/EconomicNewsViewModel.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Combine
+
+class EconomicNewsViewModel: ObservableObject {
+
+    @Published var newsItemsByCountry: [NewsCountry: [EconomicNewsItem]] = [:]
+    // To maintain a consistent order for sections in the View
+    @Published var countries: [NewsCountry] = []
+    @Published var isLoading: Bool = false
+
+    init() {
+        fetchNews()
+    }
+
+    func fetchNews() {
+        isLoading = true
+        DispatchQueue.global(qos: .userInitiated).async {
+            let allNews = DummyNewsGenerator.generateAllNews()
+
+            // Group news items by country
+            let groupedNews = Dictionary(grouping: allNews, by: { $0.country })
+
+            // Determine the order of countries for display
+            // Option 1: All countries defined in NewsCountry.allCases, even if they have no news
+            // let sortedCountries = NewsCountry.allCases
+
+            // Option 2: Only countries that have news, sorted by their definition order in NewsCountry enum
+            var presentCountries: [NewsCountry] = []
+            for countryCase in NewsCountry.allCases { // Iterate in defined order
+                if groupedNews[countryCase] != nil {
+                    presentCountries.append(countryCase)
+                }
+            }
+
+            DispatchQueue.main.async {
+                self.newsItemsByCountry = groupedNews
+                self.countries = presentCountries // Use the sorted list of countries that have news
+                self.isLoading = false
+            }
+        }
+    }
+}

--- a/iOS/ViewModels/ForexViewModel.swift
+++ b/iOS/ViewModels/ForexViewModel.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Combine // For ObservableObject and @Published
+
+class ForexViewModel: ObservableObject {
+
+    @Published var selectedPair: ForexPair {
+        didSet {
+            fetchChartData()
+        }
+    }
+    @Published var selectedPeriod: ChartPeriod {
+        didSet {
+            fetchChartData()
+        }
+    }
+    @Published var chartDataPoints: [ForexDataPoint] = []
+    @Published var isLoading: Bool = false // Optional, for future API integration
+
+    init(initialPair: ForexPair = .mxnjpy, initialPeriod: ChartPeriod = .thirtyDays) {
+        self.selectedPair = initialPair
+        self.selectedPeriod = initialPeriod
+        fetchChartData() // Initial data load
+    }
+
+    func fetchChartData() {
+        isLoading = true // Optional
+        let days = DummyDataGenerator.days(for: selectedPeriod)
+        // Generate data on a background thread to avoid blocking UI, though for dummy data it's very fast.
+        // For real API calls, this would be essential.
+        DispatchQueue.global(qos: .userInitiated).async {
+            let generatedData = DummyDataGenerator.generateData(for: self.selectedPair, days: days)
+            DispatchQueue.main.async {
+                self.chartDataPoints = generatedData
+                self.isLoading = false // Optional
+            }
+        }
+    }
+
+    func updatePair(to newPair: ForexPair) {
+        guard self.selectedPair != newPair else { return } // Avoid redundant updates
+        self.selectedPair = newPair
+        // fetchChartData() will be called by didSet
+    }
+
+    func updatePeriod(to newPeriod: ChartPeriod) {
+        guard self.selectedPeriod != newPeriod else { return } // Avoid redundant updates
+        self.selectedPeriod = newPeriod
+        // fetchChartData() will be called by didSet
+    }
+}

--- a/iOS/Views/ContentView.swift
+++ b/iOS/Views/ContentView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        TabView {
+            ForexChartView()
+                .tabItem {
+                    Label("為替チャート", systemImage: "chart.line.uptrend.xyaxis")
+                }
+
+            EconomicNewsView()
+                .tabItem {
+                    Label("経済ニュース", systemImage: "newspaper")
+                }
+        }
+    }
+}

--- a/iOS/Views/EconomicNewsView.swift
+++ b/iOS/Views/EconomicNewsView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+struct EconomicNewsView: View {
+    @StateObject private var viewModel = EconomicNewsViewModel()
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                if viewModel.isLoading {
+                    ProgressView("経済ニュースを読み込み中...")
+                        .padding()
+                } else if viewModel.countries.isEmpty {
+                    Text("表示できる経済ニュースがありません。")
+                        .foregroundColor(.secondary)
+                        .padding()
+                } else {
+                    List {
+                        ForEach(viewModel.countries) { country in
+                            Section(header: Text(country.rawValue).font(.headline)) {
+                                if let newsItems = viewModel.newsItemsByCountry[country], !newsItems.isEmpty {
+                                    ForEach(newsItems) { item in
+                                        newsItemRow(item: item)
+                                    }
+                                } else {
+                                    // This case should ideally not happen if countries list is derived from non-empty newsItemsByCountry keys
+                                    Text("この国のニュースはありません。")
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                        }
+                    }
+                    .listStyle(InsetGroupedListStyle()) // Or .plain, .grouped
+                }
+            }
+            .navigationTitle("経済ニュース")
+            .navigationBarTitleDisplayMode(.inline) // Or .large
+            // Optional: Add a refresh button if you want to manually trigger fetchNews
+            // .toolbar {
+            //     ToolbarItem(placement: .navigationBarTrailing) {
+            //         Button {
+            //             viewModel.fetchNews()
+            //         } label: {
+            //             Image(systemName: "arrow.clockwise")
+            //         }
+            //     }
+            // }
+        }
+    }
+
+    // Helper view for displaying a single news item row
+    @ViewBuilder
+    private func newsItemRow(item: EconomicNewsItem) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(item.indicator.descriptiveTitle)
+                .font(.title3)
+                .fontWeight(.semibold)
+
+            HStack {
+                Text("発表日:")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                Text(item.publishedDateString)
+                    .font(.caption)
+            }
+
+            Text(item.value)
+                .font(.body)
+                .padding(.vertical, 2)
+
+            if let notes = item.notes, !notes.isEmpty {
+                Text(notes)
+                    .font(.footnote)
+                    .foregroundColor(.gray)
+                    .padding(.top, 2)
+            }
+
+            if let link = item.sourceLink {
+                Link("情報源を見る", destination: link)
+                    .font(.caption)
+                    .padding(.top, 2)
+            }
+        }
+        .padding(.vertical, 8) // Add some padding to each row
+    }
+}
+
+// Preview Provider
+struct EconomicNewsView_Previews: PreviewProvider {
+    static var previews: some View {
+        EconomicNewsView()
+    }
+}

--- a/iOS/Views/ForexChartView.swift
+++ b/iOS/Views/ForexChartView.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+import Charts // Import Swift Charts
+
+struct ForexChartView: View {
+    @StateObject private var viewModel = ForexViewModel()
+
+    var body: some View {
+        NavigationView { // For a title bar, can be adjusted based on app structure
+            VStack {
+                // Currency Pair Picker
+                Picker("Currency Pair", selection: $viewModel.selectedPair) {
+                    ForEach(ForexPair.allCases) { pair in
+                        Text(pair.rawValue).tag(pair)
+                    }
+                }
+                .pickerStyle(SegmentedPickerStyle()) // Or .automatic, .menu based on preference
+                .padding(.horizontal)
+
+                // Chart Period Picker
+                Picker("Period", selection: $viewModel.selectedPeriod) {
+                    ForEach(ChartPeriod.allCases) { period in
+                        Text(period.rawValue).tag(period)
+                    }
+                }
+                .pickerStyle(SegmentedPickerStyle())
+                .padding(.horizontal)
+
+                // Chart Area
+                if viewModel.isLoading {
+                    ProgressView("Loading Chart...")
+                        .frame(height: 300) // Give some space for the loader
+                } else if viewModel.chartDataPoints.isEmpty {
+                    Text("No data available for the selected period.")
+                        .frame(height: 300)
+                } else {
+                    Chart {
+                        ForEach(viewModel.chartDataPoints) { dataPoint in
+                            LineMark(
+                                x: .value("Date", dataPoint.date, unit: .day), // Specify unit for date
+                                y: .value("Price (Close)", dataPoint.close)
+                            )
+                            // Optional: Add AreaMark for a filled effect below the line
+                            // AreaMark(
+                            //     x: .value("Date", dataPoint.date, unit: .day),
+                            //     yStart: .value("Min Price", viewModel.chartDataPoints.map{$0.low}.min() ?? 0), // Or a fixed baseline
+                            //     yEnd: .value("Price (Close)", dataPoint.close)
+                            // )
+                            // .opacity(0.3)
+
+                            // Optional: RuleMark for High/Low range (Candle Stick like)
+                            // For a full candlestick, you'd typically use RectangleMark for the body
+                            // and RuleMark for the wicks. Here's a simplified high/low line.
+                            RuleMark(
+                                x: .value("Date", dataPoint.date, unit: .day),
+                                yStart: .value("Low", dataPoint.low),
+                                yEnd: .value("High", dataPoint.high)
+                            )
+                            .foregroundStyle(Color.gray.opacity(0.5))
+                        }
+                    }
+                    .chartXAxis {
+                        AxisMarks(values: .stride(by: .day, count: xStrideCount())) { value in
+                            AxisGridLine()
+                            AxisTick()
+                            AxisValueLabel(format: .dateTime.month().day(), centered: false)
+                        }
+                    }
+                    .chartYAxis {
+                        AxisMarks { value in // Default ticks and lines
+                            AxisGridLine()
+                            AxisTick()
+                            AxisValueLabel() // Default formatting for Double
+                        }
+                    }
+                    .frame(height: 300) // Example height
+                    .padding()
+                }
+
+                Spacer() // Push content to the top
+            }
+            .navigationTitle(viewModel.selectedPair.rawValue) // Display selected pair as title
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    // Helper function to determine X-axis stride based on period
+    private func xStrideCount() -> Int {
+        switch viewModel.selectedPeriod {
+        case .tenDays:
+            return 1 // Show every day
+        case .thirtyDays:
+            return 3 // Show every 3 days
+        case .sixMonths:
+            return 15 // Show every 15 days (approx twice a month)
+        case .oneYear:
+            return 30 // Show every 30 days (approx monthly)
+        case .fiveYears:
+            return 365 // Show approx yearly
+        }
+    }
+}
+
+// Preview Provider (Optional but recommended)
+struct ForexChartView_Previews: PreviewProvider {
+    static var previews: some View {
+        ForexChartView()
+    }
+}

--- a/src/components/ForexDisplay/ForexDisplay.css
+++ b/src/components/ForexDisplay/ForexDisplay.css
@@ -1,0 +1,92 @@
+.forex-display-container {
+  font-family: sans-serif;
+  padding: 20px;
+  background-color: #f9f9f9;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.controls-section {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 20px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #eee;
+}
+
+.pair-selector,
+.period-selector {
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  background-color: #fff;
+}
+
+.pair-selector h3,
+.period-selector h3 {
+  margin-top: 0;
+  font-size: 1em;
+  color: #333;
+}
+
+.pair-selector button,
+.period-selector button {
+  background-color: #e7e7e7;
+  border: 1px solid #ccc;
+  color: #333;
+  padding: 8px 12px;
+  margin-right: 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.pair-selector button:last-child,
+.period-selector button:last-child {
+  margin-right: 0;
+}
+
+.pair-selector button:hover,
+.period-selector button:hover {
+  background-color: #dcdcdc;
+}
+
+.pair-selector button.active,
+.period-selector button.active {
+  background-color: #007bff;
+  color: white;
+  border-color: #007bff;
+}
+
+.chart-section {
+  margin-top: 20px;
+}
+
+.chart-section h3 {
+  font-size: 1.2em;
+  color: #333;
+  margin-bottom: 10px;
+}
+
+.chart-placeholder {
+  height: 300px; /* Adjust as needed */
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  color: #777;
+  padding: 20px;
+}
+
+.chart-placeholder p {
+  margin: 5px 0;
+}
+
+.chart-placeholder pre {
+  width: 90%; /* Ensure pre tag takes up most of the placeholder width */
+  font-size: 0.8em; /* Smaller font for data dump */
+}

--- a/src/components/ForexDisplay/ForexDisplay.tsx
+++ b/src/components/ForexDisplay/ForexDisplay.tsx
@@ -1,0 +1,77 @@
+import React, { useState, useEffect } from 'react';
+import { ForexDataPoint, ForexPair, TimePeriod } from './types';
+import { getFilteredData, dummyForexData } from './dummyData';
+import './ForexDisplay.css';
+
+const ForexDisplay: React.FC = () => {
+  const [selectedPair, setSelectedPair] = useState<ForexPair>('MXN/JPY');
+  const [selectedPeriod, setSelectedPeriod] = useState<TimePeriod>('1Y');
+  const [displayData, setDisplayData] = useState<ForexDataPoint[]>([]);
+
+  useEffect(() => {
+    setDisplayData(getFilteredData(selectedPair, selectedPeriod));
+  }, [selectedPair, selectedPeriod]);
+
+  const handlePairChange = (pair: ForexPair) => {
+    setSelectedPair(pair);
+  };
+
+  const handlePeriodChange = (period: TimePeriod) => {
+    setSelectedPeriod(period);
+  };
+
+  const timePeriods: TimePeriod[] = ['10D', '30D', '6M', '1Y', '5Y'];
+  const forexPairs: ForexPair[] = ['MXN/JPY', 'ZAR/JPY'];
+
+  return (
+    <div className="forex-display-container">
+      <h2>Exchange Rate Charts</h2>
+
+      <div className="controls-section">
+        <div className="pair-selector">
+          <h3>Select Currency Pair:</h3>
+          {forexPairs.map(pair => (
+            <button
+              key={pair}
+              onClick={() => handlePairChange(pair)}
+              className={selectedPair === pair ? 'active' : ''}
+            >
+              {pair}
+            </button>
+          ))}
+        </div>
+
+        <div className="period-selector">
+          <h3>Select Period:</h3>
+          {timePeriods.map(period => (
+            <button
+              key={period}
+              onClick={() => handlePeriodChange(period)}
+              className={selectedPeriod === period ? 'active' : ''}
+            >
+              {period}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="chart-section">
+        <h3>{selectedPair} - {selectedPeriod}</h3>
+        {/* Placeholder for the chart */}
+        <div className="chart-placeholder">
+          <p>Chart for {selectedPair} will be displayed here.</p>
+          <p>{displayData.length} data points</p>
+          {/* Basic data display for now */}
+          <pre style={{ textAlign: 'left', maxHeight: '200px', overflowY: 'auto', background: '#f0f0f0', padding: '10px'}}>
+            {displayData.map(d => `${d.date} O:${d.open} H:${d.high} L:${d.low} C:${d.close}`).join('\n')}
+          </pre>
+        </div>
+      </div>
+
+      {/* Placeholder for ZAR/JPY chart if needed, or a single chart that updates */}
+      {/* For simplicity, we'll use one chart placeholder that updates based on selectedPair */}
+    </div>
+  );
+};
+
+export default ForexDisplay;

--- a/src/components/ForexDisplay/dummyData.ts
+++ b/src/components/ForexDisplay/dummyData.ts
@@ -1,0 +1,80 @@
+import { ForexDataPoint, ForexData, ForexPair } from './types';
+
+const generateRandomPrice = (basePrice: number): number => {
+  // Generate a price within +/- 5% of the base price
+  return basePrice * (1 + (Math.random() - 0.5) * 0.1);
+};
+
+const generateDataPoint = (date: Date, lastClose: number): ForexDataPoint => {
+  const open = lastClose * (1 + (Math.random() - 0.5) * 0.02); // Open price within +/- 1% of last close
+  const high = Math.max(open, open * (1 + Math.random() * 0.03)); // High is open or higher (up to 3% more)
+  const low = Math.min(open, open * (1 - Math.random() * 0.03));   // Low is open or lower (up to 3% less)
+  const close = generateRandomPrice(open); // Close price based on open
+
+  return {
+    date: date.toISOString().split('T')[0], // Format as YYYY-MM-DD
+    open: parseFloat(open.toFixed(4)),
+    high: parseFloat(high.toFixed(4)),
+    low: parseFloat(low.toFixed(4)),
+    close: parseFloat(close.toFixed(4)),
+  };
+};
+
+const generateForexData = (pair: ForexPair, days: number): ForexData => {
+  const data: ForexDataPoint[] = [];
+  let currentDate = new Date();
+  currentDate.setDate(currentDate.getDate() - days); // Start from 'days' ago
+
+  // Initial base prices for pairs (can be adjusted)
+  let lastClose = pair === 'MXN/JPY' ? 8.5 : 5.0;
+
+  for (let i = 0; i < days; i++) {
+    const newDataPoint = generateDataPoint(currentDate, lastClose);
+    data.push(newDataPoint);
+    lastClose = newDataPoint.close;
+    currentDate.setDate(currentDate.getDate() + 1);
+  }
+
+  return {
+    pair,
+    data,
+  };
+};
+
+// Generate data for 5 years (approx 365 * 5 days)
+const MXN_JPY_DATA = generateForexData('MXN/JPY', 365 * 5 + 2); // Add a couple of extra for buffer
+const ZAR_JPY_DATA = generateForexData('ZAR/JPY', 365 * 5 + 2);
+
+export const dummyForexData: Record<ForexPair, ForexData> = {
+  'MXN/JPY': MXN_JPY_DATA,
+  'ZAR/JPY': ZAR_JPY_DATA,
+};
+
+export const getFilteredData = (pair: ForexPair, period: TimePeriod): ForexDataPoint[] => {
+  const allData = dummyForexData[pair].data;
+  const today = new Date();
+  let startDate = new Date(today);
+
+  switch (period) {
+    case '10D':
+      startDate.setDate(today.getDate() - 10);
+      break;
+    case '30D':
+      startDate.setDate(today.getDate() - 30);
+      break;
+    case '6M':
+      startDate.setMonth(today.getMonth() - 6);
+      break;
+    case '1Y':
+      startDate.setFullYear(today.getFullYear() - 1);
+      break;
+    case '5Y':
+      startDate.setFullYear(today.getFullYear() - 5);
+      break;
+    default:
+      return allData; // Should not happen
+  }
+
+  const filterStartDateStr = startDate.toISOString().split('T')[0];
+  return allData.filter(point => point.date >= filterStartDateStr);
+};

--- a/src/components/ForexDisplay/types.ts
+++ b/src/components/ForexDisplay/types.ts
@@ -1,0 +1,16 @@
+export interface ForexDataPoint {
+  date: string; // YYYY-MM-DD
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}
+
+export type ForexPair = 'MXN/JPY' | 'ZAR/JPY';
+
+export interface ForexData {
+  pair: ForexPair;
+  data: ForexDataPoint[];
+}
+
+export type TimePeriod = '10D' | '30D' | '6M' | '1Y' | '5Y';


### PR DESCRIPTION
I've implemented the initial set of features for your iOS Forex application based on issue #1.

Features included:
- Forex Chart Display:
  - Displays OHLC data for MXN/JPY and ZAR/JPY using line and rule marks (simulating candlestick).
  - Allows period switching (10D, 30D, 6M, 1Y, 5Y).
  - Uses dummy data for chart population.
- Economic News Display:
  - Shows latest economic indicators (Trade Balance, Interest Rates, CPI) for Mexico, South Africa, Japan, and the USA.
  - News items are grouped by country and displayed in a list.
  - Uses dummy data for news population.
- Push Notification Setup (Price Alerts):
  - Basic setup for receiving push notifications from a backend service.
  - Handles foreground notification display and logs notification taps.
  - Push notification payload specification documented in README.md.
- Unit Tests:
  - Added unit tests for ViewModels (`ForexViewModel`, `EconomicNewsViewModel`).
  - Added unit tests for dummy data generators (`DummyDataGenerator`, `DummyNewsGenerator`).

All UI elements are implemented using SwiftUI and follow an MVVM architecture. This commit delivers the Minimum Viable Product (MVP) for the iOS portion of the application as per the issue requirements addressed so far. Android implementation will follow separately.